### PR TITLE
Correção de importação de ícones svg

### DIFF
--- a/detalhes-banana.html
+++ b/detalhes-banana.html
@@ -18,11 +18,7 @@
             <div class="slds-builder-header__item">
                 <a href="index.html" class="slds-builder-header__item-action" title="Voltar">
                     <span class="slds-icon_container slds-icon-utility-back slds-current-color">
-                        <svg class="slds-icon slds-icon_x-small" aria-hidden="true">
-                            <use
-                                xlink:href="salesforce-lightning-design-system-2.16.2/assets/icons/utility-sprite/svg/symbols.svg#back">
-                            </use>
-                        </svg>
+                        <img class="slds-icon slds-icon_x-small" src="salesforce-lightning-design-system-2.16.2\assets\icons\utility\back.svg">
                         <span class="slds-assistive-text">Voltar</span>
                     </span>
                 </a>
@@ -32,11 +28,7 @@
                 <div class="slds-builder-header__item-label slds-media slds-media_center">
                     <div class="slds-media__figure">
                         <span class="slds-icon_container slds-icon-utility-builder slds-current-color">
-                            <svg class="slds-icon slds-icon_x-small" aria-hidden="true">
-                                <use
-                                    xlink:href="/salesforce-lightning-design-system-2.16.2/assets/icons/utility-sprite/svg/symbols.svg#builder">
-                                </use>
-                            </svg>
+                            <img class="slds-icon slds-icon_x-small" src="salesforce-lightning-design-system-2.16.2\assets\icons\utility\builder.svg">
                         </span>
                     </div>
                     <div class="slds-media__body">Frutipédia</div>
@@ -54,11 +46,7 @@
                     <a href="/referencias.html" class="slds-builder-header__item-action slds-media slds-media_center">
                         <span class="slds-media__figure">
                             <span class="slds-icon_container slds-icon-utility-settings slds-current-color">
-                                <svg class="slds-icon slds-icon_x-small" aria-hidden="true">
-                                    <use
-                                        xlink:href="salesforce-lightning-design-system-2.16.2/assets/icons/utility-sprite/svg/symbols.svg#help">
-                                    </use>
-                                </svg>
+                                <img class="slds-icon slds-icon_x-small" src="salesforce-lightning-design-system-2.16.2\assets\icons\utility\help.svg">
                             </span>
                         </span>
                         <span class="slds-media__body">
@@ -83,11 +71,7 @@
                         <div class="slds-media">
                             <div class="slds-media__figure">
                                 <span class="slds-icon_container slds-icon-standard-opportunity" title="opportunity">
-                                    <svg class="slds-icon slds-page-header__icon" aria-hidden="true">
-                                        <use
-                                            xlink:href="/salesforce-lightning-design-system-2.16.2/assets/icons/standard-sprite/svg/symbols.svg#all">
-                                        </use>
-                                    </svg>
+                                    <img class="slds-icon slds-page-header__icon" src="salesforce-lightning-design-system-2.16.2\assets\icons\standard\all.svg">
                                     <span class="slds-assistive-text">Nome da fruta</span>
                                 </span>
                             </div>
@@ -115,18 +99,14 @@
                         <header class="slds-media slds-media_center slds-has-flexi-truncate">
                             <div class="slds-media__figure">
                                 <span class="slds-icon_container slds-icon-standard-account" title="account">
-                                    <svg class="slds-icon slds-icon_small" aria-hidden="true">
-                                        <use
-                                            xlink:href="/salesforce-lightning-design-system-2.16.2/assets/icons/standard-sprite/svg/symbols.svg#text">
-                                        </use>
-                                    </svg>
+                                    <img class="slds-icon slds-icon_small" src="salesforce-lightning-design-system-2.16.2\assets\icons\standard\text.svg">
                                     <span class="slds-assistive-text">descrição da fruta</span>
                                 </span>
                             </div>
                             <div class="slds-media__body">
                                 <h2 class="slds-card__header-title">
                                     <span>Descrição</span>
-                                    </a>
+                                </h2>
                             </div>
                         </header>
                     </div>
@@ -147,11 +127,7 @@
                         <header class="slds-media slds-media_center slds-has-flexi-truncate">
                             <div class="slds-media__figure">
                                 <span class="slds-icon_container slds-icon-standard-account" title="account">
-                                    <svg class="slds-icon slds-icon_small" aria-hidden="true">
-                                        <use
-                                            xlink:href="salesforce-lightning-design-system-2.16.2/assets/icons/utility-sprite/svg/symbols.svg#chat">
-                                        </use>
-                                    </svg>
+                                    <img class="slds-icon slds-icon_small" src="salesforce-lightning-design-system-2.16.2\assets\icons\utility\chat.svg">
                                     <span class="slds-assistive-text">Curiosidade sobre fruta</span>
                                 </span>
                             </div>
@@ -178,11 +154,7 @@
                         <header class="slds-media slds-media_center slds-has-flexi-truncate">
                             <div class="slds-media__figure">
                                 <span class="slds-icon_container slds-icon-standard-task" title="task">
-                                    <svg class="slds-icon slds-icon_small" aria-hidden="true">
-                                        <use
-                                            xlink:href="salesforce-lightning-design-system-2.16.2/assets/icons/standard-sprite/svg/symbols.svg#photo">
-                                        </use>
-                                    </svg>
+                                    <img class="slds-icon slds-icon_small" src="salesforce-lightning-design-system-2.16.2\assets\icons\standard\photo.svg">
                                     <span class="slds-assistive-text">imagem</span>
                                 </span>
                             </div>
@@ -208,11 +180,7 @@
                     <header class="slds-media slds-media_center slds-has-flexi-truncate">
                         <div class="slds-media__figure">
                             <span class="slds-icon_container slds-icon-standard-account" title="account">
-                                <svg class="slds-icon slds-icon_small" aria-hidden="true">
-                                    <use
-                                        xlink:href="salesforce-lightning-design-system-2.16.2/assets/icons/standard-sprite/svg/symbols.svg#account">
-                                    </use>
-                                </svg>
+                                <img class="slds-icon slds-icon_small" src="salesforce-lightning-design-system-2.16.2\assets\icons\standard\account.svg">
                                 <span class="slds-assistive-text">receita</span>
                             </span>
                         </div>
@@ -252,11 +220,7 @@
                     <header class="slds-media slds-media_center slds-has-flexi-truncate">
                         <div class="slds-media__figure">
                             <span class="slds-icon_container slds-icon-standard-account" title="account">
-                                <svg class="slds-icon slds-icon_small" aria-hidden="true">
-                                    <use
-                                        xlink:href="salesforce-lightning-design-system-2.16.2/assets/icons/standard-sprite/svg/symbols.svg#account">
-                                    </use>
-                                </svg>
+                                <img class="slds-icon slds-icon_small" src="salesforce-lightning-design-system-2.16.2\assets\icons\standard\account.svg">
                                 <span class="slds-assistive-text">Informações nutricionais</span>
                             </span>
                         </div>
@@ -275,11 +239,7 @@
                             <header class="slds-media slds-media_center slds-has-flexi-truncate">
                                 <div class="slds-media__figure">
                                     <span class="slds-icon_container slds-icon-standard-account" title="account">
-                                        <svg class="slds-icon slds-icon_small" aria-hidden="true">
-                                            <use
-                                                xlink:href="salesforce-lightning-design-system-2.16.2/assets/icons/standard-sprite/svg/symbols.svg#account">
-                                            </use>
-                                        </svg>
+                                        <img class="slds-icon slds-icon_small" src="salesforce-lightning-design-system-2.16.2\assets\icons\standard\account.svg">
                                         <span class="slds-assistive-text">Calorias</span>
                                     </span>
                                 </div>
@@ -320,11 +280,7 @@
                             <header class="slds-media slds-media_center slds-has-flexi-truncate">
                                 <div class="slds-media__figure">
                                     <span class="slds-icon_container slds-icon-standard-account" title="account">
-                                        <svg class="slds-icon slds-icon_small" aria-hidden="true">
-                                            <use
-                                                xlink:href="salesforce-lightning-design-system-2.16.2/assets/icons/standard-sprite/svg/symbols.svg#account">
-                                            </use>
-                                        </svg>
+                                        <img class="slds-icon slds-icon_small" src="salesforce-lightning-design-system-2.16.2\assets\icons\standard\account.svg">
                                         <span class="slds-assistive-text">Carboidratos</span>
                                     </span>
                                 </div>
@@ -365,11 +321,7 @@
                             <header class="slds-media slds-media_center slds-has-flexi-truncate">
                                 <div class="slds-media__figure">
                                     <span class="slds-icon_container slds-icon-standard-account" title="account">
-                                        <svg class="slds-icon slds-icon_small" aria-hidden="true">
-                                            <use
-                                                xlink:href="salesforce-lightning-design-system-2.16.2/assets/icons/standard-sprite/svg/symbols.svg#account">
-                                            </use>
-                                        </svg>
+                                        <img class="slds-icon slds-icon_small" src="salesforce-lightning-design-system-2.16.2\assets\icons\standard\account.svg">
                                         <span class="slds-assistive-text">Vitaminas</span>
                                     </span>
                                 </div>


### PR DESCRIPTION
Os ícones svg podem ser importados de algumas maneiras diferentes, a maneira mais fácil é utilizar uma anchor tag e importar como uma imagem normal.

Realizei a correção de importação das imagens da página de detalhes da banana, segue imagem do resultado final:

<img width="854" alt="Screenshot 2021-11-14 011653" src="https://user-images.githubusercontent.com/3721845/141667370-d8eb387f-3f35-4baf-a0a1-2bfdd6ea97fa.png">


